### PR TITLE
feat: Streamline OAuth 2.0 flow

### DIFF
--- a/SLACK AUTH-1616374332194.sql
+++ b/SLACK AUTH-1616374332194.sql
@@ -1,0 +1,91 @@
+
+CREATE TABLE BotUser
+(
+  ID          text              NOT NULL,
+  SCOPE       character varying,
+  ACCESSTOKEN character varying,
+  BOTUSERID   character varying,
+  CREATEDDATE timestamptz      ,
+  UPDATEDDATE timestamptz      ,
+  WorkspaceID text             
+);
+
+COMMENT ON TABLE BotUser IS 'Slack creates a bot user on the workspace';
+
+CREATE TABLE Enteprise
+(
+  ID          text        NOT NULL,
+  NAME        text       ,
+  CREATEDDATE timestamptz,
+  UPDATEDDATE timestamptz,
+  PRIMARY KEY (ID)
+);
+
+COMMENT ON TABLE Enteprise IS 'An enterprise in Slack is the central entity of Slack’s Enterprise grid plan.';
+
+COMMENT ON COLUMN Enteprise.ID IS 'Unique across all of Slack';
+
+CREATE TABLE GlobalUser
+(
+  ID                text        NOT NULL,
+  SLACKGLOBALUSERID text       ,
+  CREATEDDATE       timestamptz,
+  UPDATEDDATE       timestamptz,
+  ENTERPRISEID      text       ,
+  PRIMARY KEY (ID)
+);
+
+COMMENT ON COLUMN GlobalUser.ENTERPRISEID IS 'Unique across all of Slack';
+
+CREATE TABLE LocalUser
+(
+  ID           text        NOT NULL,
+  LOCALUSERID  text       ,
+  CREATEDDATE  timestamptz,
+  UPDATEDDATE  timestamptz,
+  WORKSPACEID  text       ,
+  GLOBALUSERID text       ,
+  PRIMARY KEY (ID)
+);
+
+COMMENT ON TABLE LocalUser IS 'Local User of the Slack';
+
+CREATE TABLE WorkSpace
+(
+  ID             text        NOT NULL,
+  NAME           text       ,
+  ISAPPINSTALLED boolean     DEFAULT FALSE,
+  CREATEDDATE    timestamptz,
+  UPDATEDATE     timestamptz,
+  ENTERPRISEID   text       ,
+  PRIMARY KEY (ID)
+);
+
+COMMENT ON TABLE WorkSpace IS 'It’s a foundational Slack entity and many Slack entities strongly relate back to the workspace';
+
+COMMENT ON COLUMN WorkSpace.ENTERPRISEID IS 'Unique across all of Slack';
+
+ALTER TABLE WorkSpace
+  ADD CONSTRAINT FK_Enteprise_TO_WorkSpace
+    FOREIGN KEY (ENTERPRISEID)
+    REFERENCES Enteprise (ID);
+
+ALTER TABLE GlobalUser
+  ADD CONSTRAINT FK_Enteprise_TO_GlobalUser
+    FOREIGN KEY (ENTERPRISEID)
+    REFERENCES Enteprise (ID);
+
+ALTER TABLE BotUser
+  ADD CONSTRAINT FK_WorkSpace_TO_BotUser
+    FOREIGN KEY (WorkspaceID)
+    REFERENCES WorkSpace (ID);
+
+ALTER TABLE LocalUser
+  ADD CONSTRAINT FK_WorkSpace_TO_LocalUser
+    FOREIGN KEY (WORKSPACEID)
+    REFERENCES WorkSpace (ID);
+
+ALTER TABLE LocalUser
+  ADD CONSTRAINT FK_GlobalUser_TO_LocalUser
+    FOREIGN KEY (GLOBALUSERID)
+    REFERENCES GlobalUser (ID);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const jsforce = require('jsforce'); //jsforce open source library to connect to 
 
 // Create Salesforce Connection
 const oauth2 = new jsforce.OAuth2({
-    // you can change loginUrl to connect to sandbox or prerelease env.
+    // you can change loginUrl to connect to sandbox or scratchorg env.
     // loginUrl : 'https://test.salesforce.com',
     clientId: process.env.SALESFORCE_CLIENT_ID,
     clientSecret: process.env.SALESFORCE_CLIENT_SECRET,
@@ -11,7 +11,11 @@ const oauth2 = new jsforce.OAuth2({
 });
 const connection = new jsforce.Connection({ oauth2: oauth2 });
 
+// This is hack at this point. This needs to be stored in Database
+let oAuthResponseFromSlackInstall = {};
+
 // Create a Reciever for Installation and OAuth with Slack and Salesforce
+// One needs ExpressReciever if you want to take complete control of the OAuth 2.0 dance
 const receiver = new ExpressReceiver({
     signingSecret: process.env.SLACK_SIGNING_SECRET,
     clientId: process.env.SLACK_CLIENT_ID,
@@ -32,36 +36,11 @@ const receiver = new ExpressReceiver({
     installerOptions: {
         authVersion: 'v2', // default  is 'v2', 'v1' is used for classic slack apps
         installPath: '/slack/install',
-        redirectUriPath: '/slack/oauth_redirect',
         callbackOptions: {
             success: async (installation, installOptions, req, res) => {
                 try {
-                    await say({
-                        blocks: [
-                            {
-                                "type": "section",
-                                "text": {
-                                    "type": "mrkdwn",
-                                    "text": "To login into Salesforce click the button below"
-                                }
-                            },
-                            {
-                                "type": "actions",
-                                "elements": [
-                                    {
-                                        "type": "button",
-                                        "text": {
-                                            "type": "plain_text",
-                                            "text": "Authorize Salesforce"
-                                        },
-                                        "value": "authsfdc",
-                                        "action_id": "authsf"
-                                    }
-                                ]
-                            }
-                        ]
-                    })
-                    res.send('The app is successfully installed! You can close this window!!!!');
+                    oAuthResponseFromSlackInstall = installation;
+                    res.redirect('/slack/appinstall/success');
                 } catch (error) {
                     throw error;
                 }
@@ -71,7 +50,9 @@ const receiver = new ExpressReceiver({
                 res.send('failure');
             }
         }
-    },
+    }
+    // TODO Implement a install store to persist the tokens as per the below docs
+    // https://slack.dev/bolt-js/concepts#authenticating-oauth
 });
 
 // Instantiate Slack App with Custom Reciever
@@ -80,61 +61,117 @@ const app = new App({
     receiver
 });
 
+// Command to render button for Salesforce Connection
+app.command('/connectsf', async ({ command, ack, say }) => {
+    // Acknowledge command request
+    await ack();
+    const salesforce_url = `https://login.salesforce.com/services/oauth2/authorize?client_id=${process.env.SALESFORCE_CLIENT_ID}&redirect_uri=${process.env.SALESFORCE_REDIRECT_URL}&response_type=code`;
+    await say(renderAuthorizeButton(salesforce_url));
+});
+
+// Command to Acknowledge when Authorize Button is clicked
+app.action('authorize_sf', async ({ command, ack, say }) => {
+    await ack();
+});
+
+// Command to query Userinfo from Salesforce and display a Block UI
 app.command('/whoami', async ({ command, ack, say }) => {
     // Acknowledge command request
     await ack();
-    const userId = connection.userInfo.id;
-    const result = await connection.query(
-        `Select Id, Name, Phone, Email, Profile.Name FROM User WHERE ID='${userId}'`
-    );
-    console.log(result);
-    try {
-        await say({
-            blocks: [
-                {
-                    type: 'section',
-                    fields: [
-                        {
-                            type: 'mrkdwn',
-                            text: '*Name*'
-                        },
-                        {
-                            type: 'mrkdwn',
-                            text: '*Email*'
-                        },
-                        {
-                            type: 'plain_text',
-                            text: `${result.records[0].Name}`
-                        },
-                        {
-                            type: 'plain_text',
-                            text: `${result.records[0].Email}`
-                        },
-                        {
-                            type: 'mrkdwn',
-                            text: '*Phone*'
-                        },
-                        {
-                            type: 'mrkdwn',
-                            text: '*Profile Name*'
-                        },
-                        {
-                            type: 'plain_text',
-                            text: `${result.records[0].Phone}`
-                        },
-                        {
-                            type: 'plain_text',
-                            text: `${result.records[0].Profile.Name}`
-                        }
-                    ]
-                }
-            ]
-        });
-    } catch (e) {
-        console.log(e);
+    if (connection.userInfo) {
+        const userId = connection.userInfo.id;
+        const result = await connection.query(
+            `Select Id, Name, Phone, Email, Profile.Name FROM User WHERE ID='${userId}'`
+        );
+        console.log(result);
+        try {
+            await say(renderWhoamiBlock(result));
+        } catch (e) {
+            console.log(e);
+        }
+    } else {
+        const salesforce_url = `https://login.salesforce.com/services/oauth2/authorize?client_id=${process.env.SALESFORCE_CLIENT_ID}&redirect_uri=${process.env.SALESFORCE_REDIRECT_URL}&response_type=code`;
+        await say(renderAuthorizeButton(salesforce_url));
     }
 });
 
+// renders Whoami Block
+function renderWhoamiBlock(result) {
+    return {
+        blocks: [
+            {
+                type: 'section',
+                fields: [
+                    {
+                        type: 'mrkdwn',
+                        text: '*Name*'
+                    },
+                    {
+                        type: 'mrkdwn',
+                        text: '*Email*'
+                    },
+                    {
+                        type: 'plain_text',
+                        text: `${result.records[0].Name}`
+                    },
+                    {
+                        type: 'plain_text',
+                        text: `${result.records[0].Email}`
+                    },
+                    {
+                        type: 'mrkdwn',
+                        text: '*Phone*'
+                    },
+                    {
+                        type: 'mrkdwn',
+                        text: '*Profile Name*'
+                    },
+                    {
+                        type: 'plain_text',
+                        text: `${result.records[0].Phone}`
+                    },
+                    {
+                        type: 'plain_text',
+                        text: `${result.records[0].Profile.Name}`
+                    }
+                ]
+            }
+        ]
+    }
+}
+
+// Block SDK for returning the Authorize Button
+function renderAuthorizeButton(salesforce_url) {
+    return {
+        blocks: [
+            {
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: 'To login into Salesforce click the button below'
+                }
+            },
+            {
+                type: 'actions',
+                elements: [
+                    {
+                        type: 'button',
+                        text: {
+                            type: 'plain_text',
+                            text: 'Authorize Salesforce'
+                        },
+                        style: 'primary',
+                        value: 'authsf',
+                        url: salesforce_url,
+                        action_id: 'authorize_sf'
+                    }
+                ]
+            }
+        ]
+    };
+}
+
+// Upon redirect Authorize Salesforce
 receiver.router.get('/salesforce/oauth_redirect', async (req, res) => {
     let code = req.query.code;
     connection.authorize(code, function (err, userInfo) {
@@ -148,11 +185,27 @@ receiver.router.get('/salesforce/oauth_redirect', async (req, res) => {
         console.log(connection.instanceUrl);
         console.log('User ID: ' + userInfo.id);
         console.log('Org ID: ' + userInfo.organizationId);
-        // ...
-        res.send(
-            'Successfully connected slack with your Salesforce User. You can close this window'
-        ); // or your desired response
+        res.redirect('/auth/success');
+        // or your desired response
     });
+});
+
+// Custom Route for success Message
+receiver.router.get('/auth/success', async (req, res) => {
+    await app.client.chat.postMessage({'channel': oAuthResponseFromSlackInstall.incomingWebhook.channelId, 'text': 'Succcessfully authorized to Salesforce 🎉', token: oAuthResponseFromSlackInstall.bot.token});
+    res.send(
+        'Successfully connected slack with your Salesforce User. You can close this window'
+    );
+});
+
+// Custom Route for Install success Message
+receiver.router.get('/slack/appinstall/success', async (req, res) => {
+    await app.client.chat.postMessage({'channel': oAuthResponseFromSlackInstall.incomingWebhook.channelId, 'text': 'The app is Succcessfully Installed 🎊', token: oAuthResponseFromSlackInstall.bot.token});
+    res.send('The app is Successfully installed!!! You can close this window');
+});
+
+app.event('app_home_opened', ({ event, say }) => {  
+    say(`Slack Salesforce Hello App, <@${event.user}>!`);
 });
 
 (async () => {

--- a/index.js
+++ b/index.js
@@ -36,9 +36,32 @@ const receiver = new ExpressReceiver({
         callbackOptions: {
             success: async (installation, installOptions, req, res) => {
                 try {
-                    // Web based OAuth 2.0 with Salesforce upon Install
-                    const salesforce_url = `https://login.salesforce.com/services/oauth2/authorize?client_id=${process.env.SALESFORCE_CLIENT_ID}&redirect_uri=${process.env.SALESFORCE_REDIRECT_URL}&response_type=code`;
-                    res.redirect(salesforce_url);
+                    await say({
+                        blocks: [
+                            {
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": "To login into Salesforce click the button below"
+                                }
+                            },
+                            {
+                                "type": "actions",
+                                "elements": [
+                                    {
+                                        "type": "button",
+                                        "text": {
+                                            "type": "plain_text",
+                                            "text": "Authorize Salesforce"
+                                        },
+                                        "value": "authsfdc",
+                                        "action_id": "authsf"
+                                    }
+                                ]
+                            }
+                        ]
+                    })
+                    res.send('The app is successfully installed! You can close this window!!!!');
                 } catch (error) {
                     throw error;
                 }
@@ -48,7 +71,7 @@ const receiver = new ExpressReceiver({
                 res.send('failure');
             }
         }
-    }
+    },
 });
 
 // Instantiate Slack App with Custom Reciever
@@ -102,7 +125,7 @@ app.command('/whoami', async ({ command, ack, say }) => {
                         {
                             type: 'plain_text',
                             text: `${result.records[0].Profile.Name}`
-                        },
+                        }
                     ]
                 }
             ]

--- a/slack.vuerd.json
+++ b/slack.vuerd.json
@@ -1,0 +1,883 @@
+{
+  "canvas": {
+    "width": 2000,
+    "height": 2000,
+    "scrollTop": 11.11111068725586,
+    "scrollLeft": 121.52777099609375,
+    "show": {
+      "tableComment": true,
+      "columnComment": true,
+      "columnDataType": true,
+      "columnDefault": true,
+      "columnAutoIncrement": false,
+      "columnPrimaryKey": true,
+      "columnUnique": false,
+      "columnNotNull": true,
+      "relationship": true
+    },
+    "database": "PostgreSQL",
+    "databaseName": "SLACK AUTH",
+    "canvasType": "ERD",
+    "language": "Scala",
+    "tableCase": "pascalCase",
+    "columnCase": "camelCase",
+    "setting": {
+      "relationshipDataTypeSync": true,
+      "columnOrder": [
+        "columnName",
+        "columnDataType",
+        "columnNotNull",
+        "columnUnique",
+        "columnAutoIncrement",
+        "columnDefault",
+        "columnComment"
+      ]
+    }
+  },
+  "table": {
+    "tables": [
+      {
+        "name": "Enteprise",
+        "comment": "An enterprise in Slack is the central entity of Slack’s Enterprise grid plan.",
+        "columns": [
+          {
+            "name": "ID",
+            "comment": "Unique across all of Slack",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": true,
+              "unique": false,
+              "notNull": true
+            },
+            "ui": {
+              "active": false,
+              "pk": true,
+              "fk": false,
+              "pfk": false,
+              "widthName": 60,
+              "widthComment": 151,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "9f33a4c9-b9da-5cf8-ba50-4f9e7f23559c"
+          },
+          {
+            "name": "NAME",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 60,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "aa2a0109-b671-997d-dabb-6388d1b5a2b6"
+          },
+          {
+            "name": "CREATEDDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 97,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "e3791471-6300-5fc9-dee1-e1c7e976d206"
+          },
+          {
+            "name": "UPDATEDDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 97,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "10a09e69-324d-d35c-176c-3c4a2e71953f"
+          }
+        ],
+        "ui": {
+          "active": false,
+          "left": 103,
+          "top": 128,
+          "zIndex": 506,
+          "widthName": 60,
+          "widthComment": 419
+        },
+        "id": "425e26c8-a06b-fde3-77f9-86c94a63a4c9"
+      },
+      {
+        "name": "WorkSpace",
+        "comment": "It’s a foundational Slack entity and many Slack entities strongly relate back to the workspace",
+        "columns": [
+          {
+            "name": "ID",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": true,
+              "unique": false,
+              "notNull": true
+            },
+            "ui": {
+              "active": false,
+              "pk": true,
+              "fk": false,
+              "pfk": false,
+              "widthName": 60,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "e516a5db-4830-df99-c1c2-ccd41e5db5a0"
+          },
+          {
+            "name": "NAME",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 60,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "e5a34227-6ea6-f81f-4bb9-2f3d89cd04d1"
+          },
+          {
+            "name": "ISAPPINSTALLED",
+            "comment": "",
+            "dataType": "boolean",
+            "default": "FALSE",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 110,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "164a0f87-8051-d6d8-d603-6d4ef73e7258"
+          },
+          {
+            "name": "CREATEDDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 97,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "83188973-00a7-c47a-655d-ed5655792b9a"
+          },
+          {
+            "name": "UPDATEDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 88,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "27b2a783-0ae2-7491-968c-9cebba76c902"
+          },
+          {
+            "name": "ENTERPRISEID",
+            "comment": "Unique across all of Slack",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": true,
+              "pfk": false,
+              "widthName": 98,
+              "widthComment": 151,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "944b2952-0b00-886b-5b3d-b0ff07e1e55b"
+          }
+        ],
+        "ui": {
+          "active": false,
+          "left": 42,
+          "top": 374,
+          "zIndex": 495,
+          "widthName": 69,
+          "widthComment": 533
+        },
+        "id": "ec65e811-77b9-3b78-42f7-c1fae69b13fd"
+      },
+      {
+        "name": "GlobalUser",
+        "comment": "",
+        "columns": [
+          {
+            "name": "ID",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": true,
+              "unique": false,
+              "notNull": true
+            },
+            "ui": {
+              "active": false,
+              "pk": true,
+              "fk": false,
+              "pfk": false,
+              "widthName": 60,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "10d1357e-de72-9c6b-91bd-4e24d2572f47"
+          },
+          {
+            "name": "SLACKGLOBALUSERID",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 146,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "d106174d-2e8c-43d7-2322-b5d034fd3102"
+          },
+          {
+            "name": "CREATEDDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 97,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "b8f3597a-47c0-04e3-8b5f-f80424ad47db"
+          },
+          {
+            "name": "UPDATEDDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 97,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "24e89a34-df81-aabd-ade7-14f29a602b91"
+          },
+          {
+            "name": "ENTERPRISEID",
+            "comment": "Unique across all of Slack",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": true,
+              "pfk": false,
+              "widthName": 98,
+              "widthComment": 151,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "74b40a18-7b11-2bfe-cf8b-6a8051aeab2b"
+          }
+        ],
+        "ui": {
+          "active": false,
+          "left": 704,
+          "top": 117.66666603088379,
+          "zIndex": 494,
+          "widthName": 67,
+          "widthComment": 60
+        },
+        "id": "e9d878fc-007c-cf13-d013-d81c95d05c89"
+      },
+      {
+        "name": "BotUser",
+        "comment": "Slack creates a bot user on the workspace",
+        "columns": [
+          {
+            "name": "ID",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": true
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 60,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "a3ecfbf2-18ee-bf1c-abab-c173a68f7511"
+          },
+          {
+            "name": "SCOPE",
+            "comment": "",
+            "dataType": "character varying",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 60,
+              "widthComment": 60,
+              "widthDataType": 102,
+              "widthDefault": 60
+            },
+            "id": "7bc46bbb-9250-a964-b301-8582661f0496"
+          },
+          {
+            "name": "ACCESSTOKEN",
+            "comment": "",
+            "dataType": "character varying",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 100,
+              "widthComment": 60,
+              "widthDataType": 102,
+              "widthDefault": 60
+            },
+            "id": "6b3e601e-f0a5-e2a6-09e5-0eaec87cbc8f"
+          },
+          {
+            "name": "BOTUSERID",
+            "comment": "",
+            "dataType": "character varying",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 78,
+              "widthComment": 60,
+              "widthDataType": 102,
+              "widthDefault": 60
+            },
+            "id": "77625365-419e-8fd5-8cbb-a8d1ec942335"
+          },
+          {
+            "name": "CREATEDDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 97,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "c893695d-2a67-341e-6e5c-58c7f9713d9c"
+          },
+          {
+            "name": "UPDATEDDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 97,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "4cb1f828-6cbd-7ae9-fc33-0b99000a7e4b"
+          },
+          {
+            "name": "WorkspaceID",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": true,
+              "pfk": false,
+              "widthName": 80,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "245d5fa0-7f25-f9d9-3906-cd72eb499ab0"
+          }
+        ],
+        "ui": {
+          "active": false,
+          "left": 145,
+          "top": 667,
+          "zIndex": 492,
+          "widthName": 60,
+          "widthComment": 247
+        },
+        "id": "860ebc81-7077-6b76-0c6e-26d263c6d48c"
+      },
+      {
+        "name": "LocalUser",
+        "comment": "Local User of the Slack",
+        "columns": [
+          {
+            "name": "ID",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": true,
+              "unique": false,
+              "notNull": true
+            },
+            "ui": {
+              "active": false,
+              "pk": true,
+              "fk": false,
+              "pfk": false,
+              "widthName": 60,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "4c4af57f-d5ce-088c-faab-03e07c164945"
+          },
+          {
+            "name": "LOCALUSERID",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 94,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "07f71d65-4938-4e92-3966-114d5c3f9f99"
+          },
+          {
+            "name": "CREATEDDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 97,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "b60e4fd9-c65b-aec3-0676-409e7a12a91e"
+          },
+          {
+            "name": "UPDATEDDATE",
+            "comment": "",
+            "dataType": "timestamptz",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": false,
+              "pfk": false,
+              "widthName": 97,
+              "widthComment": 60,
+              "widthDataType": 72,
+              "widthDefault": 60
+            },
+            "id": "c1faf1b4-79d1-d7a4-d75c-5aedba7008fc"
+          },
+          {
+            "name": "WORKSPACEID",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": true,
+              "pfk": false,
+              "widthName": 98,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "a6776a1e-fdc9-819a-7dfb-aa94088f52cf"
+          },
+          {
+            "name": "GLOBALUSERID",
+            "comment": "",
+            "dataType": "text",
+            "default": "",
+            "option": {
+              "autoIncrement": false,
+              "primaryKey": false,
+              "unique": false,
+              "notNull": false
+            },
+            "ui": {
+              "active": false,
+              "pk": false,
+              "fk": true,
+              "pfk": false,
+              "widthName": 103,
+              "widthComment": 60,
+              "widthDataType": 60,
+              "widthDefault": 60
+            },
+            "id": "dd691721-3656-9d6b-4ca6-71d959d50288"
+          }
+        ],
+        "ui": {
+          "active": false,
+          "left": 773,
+          "top": 374,
+          "zIndex": 505,
+          "widthName": 61,
+          "widthComment": 136
+        },
+        "id": "401c67aa-e955-ff5b-95f6-ecddc93c2d79"
+      }
+    ],
+    "indexes": []
+  },
+  "memo": {
+    "memos": []
+  },
+  "relationship": {
+    "relationships": [
+      {
+        "identification": false,
+        "start": {
+          "tableId": "425e26c8-a06b-fde3-77f9-86c94a63a4c9",
+          "columnIds": [
+            "9f33a4c9-b9da-5cf8-ba50-4f9e7f23559c"
+          ],
+          "x": 358.5,
+          "y": 279,
+          "direction": "bottom"
+        },
+        "end": {
+          "tableId": "ec65e811-77b9-3b78-42f7-c1fae69b13fd",
+          "columnIds": [
+            "944b2952-0b00-886b-5b3d-b0ff07e1e55b"
+          ],
+          "x": 359,
+          "y": 374,
+          "direction": "top"
+        },
+        "id": "cbb00147-b6a7-ad51-943f-654b23782b0d",
+        "relationshipType": "OneN"
+      },
+      {
+        "identification": false,
+        "start": {
+          "tableId": "425e26c8-a06b-fde3-77f9-86c94a63a4c9",
+          "columnIds": [
+            "9f33a4c9-b9da-5cf8-ba50-4f9e7f23559c"
+          ],
+          "x": 614,
+          "y": 203.5,
+          "direction": "right"
+        },
+        "end": {
+          "tableId": "e9d878fc-007c-cf13-d013-d81c95d05c89",
+          "columnIds": [
+            "74b40a18-7b11-2bfe-cf8b-6a8051aeab2b"
+          ],
+          "x": 704,
+          "y": 203.4166660308838,
+          "direction": "left"
+        },
+        "id": "09f91f5a-a60c-bce8-3482-12812a4c4b36",
+        "relationshipType": "OneN"
+      },
+      {
+        "identification": false,
+        "start": {
+          "tableId": "ec65e811-77b9-3b78-42f7-c1fae69b13fd",
+          "columnIds": [
+            "e516a5db-4830-df99-c1c2-ccd41e5db5a0"
+          ],
+          "x": 359,
+          "y": 566,
+          "direction": "bottom"
+        },
+        "end": {
+          "tableId": "860ebc81-7077-6b76-0c6e-26d263c6d48c",
+          "columnIds": [
+            "245d5fa0-7f25-f9d9-3906-cd72eb499ab0"
+          ],
+          "x": 359.5,
+          "y": 667,
+          "direction": "top"
+        },
+        "id": "a355fa4d-e504-0ef4-992a-0825e9e03dcd",
+        "relationshipType": "OneN"
+      },
+      {
+        "identification": false,
+        "start": {
+          "tableId": "ec65e811-77b9-3b78-42f7-c1fae69b13fd",
+          "columnIds": [
+            "e516a5db-4830-df99-c1c2-ccd41e5db5a0"
+          ],
+          "x": 676,
+          "y": 470,
+          "direction": "right"
+        },
+        "end": {
+          "tableId": "401c67aa-e955-ff5b-95f6-ecddc93c2d79",
+          "columnIds": [
+            "a6776a1e-fdc9-819a-7dfb-aa94088f52cf"
+          ],
+          "x": 773,
+          "y": 470,
+          "direction": "left"
+        },
+        "id": "c7f105b8-c3d8-30b6-7474-93b614d3d731",
+        "relationshipType": "OneN"
+      },
+      {
+        "identification": false,
+        "start": {
+          "tableId": "e9d878fc-007c-cf13-d013-d81c95d05c89",
+          "columnIds": [
+            "10d1357e-de72-9c6b-91bd-4e24d2572f47"
+          ],
+          "x": 972,
+          "y": 289.1666660308838,
+          "direction": "bottom"
+        },
+        "end": {
+          "tableId": "401c67aa-e955-ff5b-95f6-ecddc93c2d79",
+          "columnIds": [
+            "dd691721-3656-9d6b-4ca6-71d959d50288"
+          ],
+          "x": 974,
+          "y": 374,
+          "direction": "top"
+        },
+        "id": "7f8b958e-cb85-7a70-1e06-c64fb17ec0cc",
+        "relationshipType": "OneN"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Added Data Model for storing tokens. Note that this is just data model design and the app is not tightly hooked to it yet
- The OAuth dance is now performed on slash command and not during app installation
- Added code to show how to work with block actions.
- Added code to show how to post messages to the Slack channel using the bot credentials